### PR TITLE
Strip leading and trailing whitespace in URL checker.

### DIFF
--- a/R/url_check.R
+++ b/R/url_check.R
@@ -53,14 +53,14 @@ check_urls <- function(path = ".",
 
   # Read in ignore urls file if it exists
   if (file.exists(ignore_urls_file)) {
-    ignore_urls <- readLines(ignore_urls_file)
+    ignore_urls <- trimws(readLines(ignore_urls_file))
   } else {
     ignore_urls <- ""
   }
 
-  # Read in ignore urls file if it exists
+  # Read in exclude file if it exists
   if (file.exists(exclude_file)) {
-    exclude_file <- readLines(exclude_file)
+    exclude_file <- trimws(readLines(exclude_file))
   } else {
     exclude_file <- ""
   }


### PR DESCRIPTION
<!--This PR Template was modified from https://github.com/AlexsLemonade/OpenPBTA-analysis/blob/master/.github/PULL_REQUEST_TEMPLATE.md-->

### Purpose/implementation Section

This PR fixes the incorrectly failing URL check referenced here: ottrproject/OTTR_Template#3

#### What changes are being implemented in this Pull Request?

In the provided ignore file example (https://github.com/fhdsl/GitHub_Automation_for_Scientists/blob/main/resources/ignore-urls.txt) the URL in question actually has an invisible trailing tab character. The tab gets included in the string when the file is read in and when the R script calls `if (url %in% ignore_urls) {` it returns false because it's doing an equality comparison.


#### What was your approach?

This change strips leading and trailing whitespace on all URLs read in from that file to avoid similar problems in the future. 

I also opened a PR to directly remove the offending tab character in the original repo in order to fix it before they pull in a new version of this library.

#### What GitHub issue does your pull request address?

closes ottrproject/OTTR_Template#3

### Tell potential reviewers what kind of feedback you are soliciting.

Spot checking the change to make sure it makes sense.