### PR TITLE
Update borrow_chapter header documentation md --> Rmd

### DIFF
--- a/R/borrow_chapter.R
+++ b/R/borrow_chapter.R
@@ -47,7 +47,7 @@
 #' # For a file in another repository:
 #' # ```{r, echo=FALSE, results='asis'}
 #' borrow_chapter(
-#'   doc_path = "docs/02-chapter_of_course.md",
+#'   doc_path = "02-chapter_of_course.Rmd",
 #'   repo_name = "ottrproject/OTTR_Template"
 #' )
 #' # ```


### PR DESCRIPTION
For Issue #16 

Updating the borrow_chapter header to show borrowing the Rmd file (even from a different repo) rather than borrowing the md file. We've had some people try to borrow the md files and then have rendering not work the way they expected.